### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#minEmoji Collection
+# minEmoji Collection
 
 Old JavaScript/CSS libraries and jQuery Plug-ins to convert Emojis into CSS Sprite images using `<span>` and `<img>` elements.
 
@@ -18,13 +18,13 @@ This repo is no longer maintained in favor of the new emoji library, is simpler,
 [jMinEmoji Demo](http://rodrigopolo.github.io/minEmoji/jMinEmoji/demo.html)  
 [minEmoji Demo](http://rodrigopolo.github.io/minEmoji/minEmoji/demo.html)  
 
-###Special Notes:  
+### Special Notes:  
  1. jMinEmoji-SVG doesn't have all assets available on the latest iOS / OS X release, but Emoji One devs will release a new version soon.  
  2. Missing emojis on unfinished sprites are replaced with Apple emojis.
  3. If you use [TweetDeck.com](http://TweetDeck.com) and want all new emojis, use [this fork](http://bit.ly/TweetDeckEmojis) I made from [Better TweetDeck](https://github.com/eramdam/BetterTweetDeck) which uses minEmoji in order to replace and input emojis.
 
 
-###jMinEmoji2 jQuery plugin:
+### jMinEmoji2 jQuery plugin:
 iOS 9.1 ready, a simple solution using PNG Sprites, usage: Include the CSS and JS into your HTML and apply the `minEmoji()` function to any jQuery selector.
 
 ```html
@@ -49,7 +49,7 @@ $(function(){
 });
 ```
 
-###jMinEmoji-SVG jQuery plugin:
+### jMinEmoji-SVG jQuery plugin:
 
 The jMinEmoji-SVG jQuery plugin is the perfect solutions for HiDPI displays, low bandwidth consumption; 127 bytes on CSS, 17.41KiB (not using gzip) on JavaScript, loading emojis on demand from very small numerically named SVG files.
 
@@ -80,7 +80,7 @@ $(function(){
 });
 ```
 
-###jMinEmoji jQuery plugin:
+### jMinEmoji jQuery plugin:
 A simple solution using PNG Sprites, usage: Include the CSS and JS into your HTML and apply the `minEmoji()` function to any jQuery selector.
 
 ```html
@@ -105,7 +105,7 @@ $(function(){
 });
 ```
 
-###minEmoji:
+### minEmoji:
 For those who like to code without jQuery, usage: Include the CSS and JS into your HTML document and call the function `minEmoji(string)` to replace a desired text.
 
 ```html
@@ -121,7 +121,7 @@ For those who like to code without jQuery, usage: Include the CSS and JS into yo
 
 -------
 
-###Why another library?
+### Why another library?
 
 Here is a post with the huge emoji image source files and full explanation: 
 http://rodrigopolo.com/codigo/minemoji-another-emoji-js-library.html
@@ -152,13 +152,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-###Emoji One assets License
+### Emoji One assets License
 Attribution required, use one of the following:
 * Emoji provided free by [Emoji One](http://emojione.com/)
 * Emoji provided free by http://emojione.com
 * Emoji set designed and offered free by [Emoji One](http://emojione.com/)
 
-###Twitter Emoji assets License
+### Twitter Emoji assets License
 Copyright 2014 Twitter, Inc and other contributors
 Graphics licensed under CC-BY 4.0: https://creativecommons.org/licenses/by/4.0/
 

--- a/jMinEmoji2/README.md
+++ b/jMinEmoji2/README.md
@@ -1,4 +1,4 @@
-#jMinEmoji2
+# jMinEmoji2
 Please don't hate me, I know this is in bower, I know I could just upgrade the darn script, BUT...
 There are so many different things to take into consideretion, heare a few of them:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
